### PR TITLE
Remove call to JTooltips / Google Web Fonts option / typo in _fluid-type.scss

### DIFF
--- a/language/en-GB/en-GB.tpl_oneweb.ini
+++ b/language/en-GB/en-GB.tpl_oneweb.ini
@@ -12,6 +12,8 @@ TPL_ONEWEB_GENERATOR_DESC="Set Joomla's generator meta."
 TPL_ONEWEB_ANALYTICS_LABEL="Google Analytics"
 TPL_ONEWEB_ANALYTICS_DESC="Insert your own Google Analytics ID here if you want. Just the ID which looks like UA-XXXXX-X"
 
+TPL_ONEWEB_USEGOOGLEFONTS_LABEL="Use Google Webfonts?"
+TPL_ONEWEB_USEGOOGLEFONTS_DESC="Choose if you'd like to use Google Web Fonts for your project"
 TPL_ONEWEB_WEBFONTS_LABEL="Google Webfonts"
 TPL_ONEWEB_WEBFONTS_DESC="If you want to use Google webfonts, build a collection at http://http://www.google.com/webfonts and then paste the link Google gives you in here."
 TPL_ONEWEB_WEBFONTS_PLACEHOLDER="Place the URL Google gives you here..."

--- a/logic.php
+++ b/logic.php
@@ -21,6 +21,7 @@ $frontpage             = $this->params->get('frontpage');
 $setGeneratorTag       = $this->params->get('setGeneratorTag');
 $analytics             = $this->params->get('analytics');
 $googleplus            = $this->params->get('googleplus');
+$useGoogleFonts        = $this->params->get('useGoogleFonts');
 $googleWebFonts        = $this->params->get('googleWebFonts');
 $twitter               = $this->params->get('twitter');
 $twitterLink           = $this->params->get('twitterLink');
@@ -88,7 +89,7 @@ if ($jQuery) {
 // Global styles
 $doc->addStyleSheet($template.'/css/style.css');
 // Google fonts styles
-if ($googleWebFonts != "") {
+if ($useGoogleFonts == 1) {
   $doc->addStyleSheet(''.$googleWebFonts.'');
 }
 //Debug stylesheet

--- a/logic.php
+++ b/logic.php
@@ -73,6 +73,8 @@ if ( !$loadMoo ) {
     unset($doc->_scripts[$this->baseurl.'/media/system/js/modal.js']);
     unset($doc->_scripts[$this->baseurl.'/media/system/js/mootools.js']);
     unset($doc->_scripts[$this->baseurl.'/plugins/system/mtupgrade/mootools.js']);
+    // Remove call to JTooltips from http://www.jsnippets.net/snippets/php/remove-call-to-jtooltips
+    $doc->_script = preg_replace('%window\.addEvent\(\'domready\',\s*function\(\)\s*{\s*\$\$\(\'.hasTip\'\).each\(function\(el\)\s*{\s*var\s*title\s*=\s*el.get\(\'title\'\);\s*if\s*\(title\)\s*{\s*var\s*parts\s*=\s*title.split\(\'::\',\s*2\);\s*el.store\(\'tip:title\',\s*parts\[0\]\);\s*el.store\(\'tip:text\',\s*parts\[1\]\);\s*}\s*}\);\s*var\s*JTooltips\s*=\s*new\s*Tips\(\$\$\(\'.hasTip\'\),\s*{\s*maxTitleChars:\s*50,\s*fixed:\s*false}\);\s*}\);', '', $doc->_script);
 }
 // Self explanatory
 if ( !$bootBloatJS ) {

--- a/scss/framework/generic/_fluid-type.scss
+++ b/scss/framework/generic/_fluid-type.scss
@@ -11,7 +11,7 @@
 			font-size: $root-font-size * 1.063%; // 17px if the root was 16px
 		}
 
-		@include media-query(desk-wide) {
+		@include media-query(deskwide) {
 			font-size: $root-font-size * 1.125%; // 18px if the root was 16px
 		}
 

--- a/templateDetails.xml
+++ b/templateDetails.xml
@@ -36,8 +36,8 @@
 		<position>debug</position>
 	</positions>
 	<languages folder="language">
-		<language tag="en-GB">en-GB/en-GB.tpl_volkersaar.ini</language>
-		<language tag="en-GB">en-GB/en-GB.tpl_volkersaar.sys.ini</language>
+		<language tag="en-GB">en-GB/en-GB.tpl_oneweb.ini</language>
+		<language tag="en-GB">en-GB/en-GB.tpl_oneweb.sys.ini</language>
 	</languages>
 	<config>
 		<fields name="params">

--- a/templateDetails.xml
+++ b/templateDetails.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE install PUBLIC "-//Joomla! 2.5//DTD template 1.0//EN" "http://www.joomla.org/xml/dtd/2.5/template-install.dtd">
 <extension version="3.0" type="template" client="site">
-	<name>oneweb</name>
-	<version>3.0</version>
-	<creationDate>30/04/2013</creationDate>
-	<author>Seth Warburton</author>
-	<authorEmail>seth@internet-inspired.com</authorEmail>
-	<copyright>Copyright (C) 2013 Internet Inspired. All rights reserved.</copyright>
+	<name>VolkerSaar</name>
+	<version>1.0</version>
+	<creationDate>05/09/2013</creationDate>
+	<author>Gerhard Sitzmann</author>
+	<authorEmail>gbrh@webseiten-fuer-alle.de</authorEmail>
+	<copyright>Copyright (C) 2013 webseiten-fuer-alle.de.</copyright>
 	<description>TPL_ONEWEB_XML_DESCRIPTION</description>
 	<files>
         <filename>apple-touch-icon.png</filename>
@@ -36,14 +36,20 @@
 		<position>debug</position>
 	</positions>
 	<languages folder="language">
-		<language tag="en-GB">en-GB/en-GB.tpl_oneweb.ini</language>
-		<language tag="en-GB">en-GB/en-GB.tpl_oneweb.sys.ini</language>
+		<language tag="en-GB">en-GB/en-GB.tpl_volkersaar.ini</language>
+		<language tag="en-GB">en-GB/en-GB.tpl_volkersaar.sys.ini</language>
+		<language tag="de-DE">de-DE/de-DE.tpl_volkersaar.ini</language>
+		<language tag="de-DE">de-DE/de-DE.tpl_volkersaar.sys.ini</language>
 	</languages>
 	<config>
 		<fields name="params">
 			<fieldset name="head" label="TPL_ONEWEB_HEAD_LABEL">
 				<field name="setGeneratorTag" type="text" default="Internet Inspired! - http://internet-inspired.com" label="TPL_ONEWEB_GENERATOR_LABEL" description="TPL_ONEWEB_GENERATOR_DESC" />
 				<field name="analytics" type="text" default="" label="TPL_ONEWEB_ANALYTICS_LABEL" description="TPL_ONEWEB_ANALYTICS_DESC" filter="raw" />
+				<field name="useGoogleFonts" type="radio" class="btn-group" default="1" label="TPL_ONEWEB_USEGOOGLEFONTS_LABEL" description="TPL_ONEWEB_USEGOOGLEFONTS_DESC">
+					<option value="0">JNO</option>
+					<option value="1">JYES</option>
+				</field>
 				<field name="googleWebFonts" type="text" default="http://fonts.googleapis.com/css?family=Lato:300,400" label="TPL_ONEWEB_WEBFONTS_LABEL" description="TPL_ONEWEB_WEBFONTS_DESC" filter="raw" />
 			</fieldset>
 			<fieldset name="customise" label="TPL_ONEWEB_ASSETS_LABEL">

--- a/templateDetails.xml
+++ b/templateDetails.xml
@@ -38,8 +38,6 @@
 	<languages folder="language">
 		<language tag="en-GB">en-GB/en-GB.tpl_volkersaar.ini</language>
 		<language tag="en-GB">en-GB/en-GB.tpl_volkersaar.sys.ini</language>
-		<language tag="de-DE">de-DE/de-DE.tpl_volkersaar.ini</language>
-		<language tag="de-DE">de-DE/de-DE.tpl_volkersaar.sys.ini</language>
 	</languages>
 	<config>
 		<fields name="params">

--- a/templateDetails.xml
+++ b/templateDetails.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE install PUBLIC "-//Joomla! 2.5//DTD template 1.0//EN" "http://www.joomla.org/xml/dtd/2.5/template-install.dtd">
 <extension version="3.0" type="template" client="site">
-	<name>VolkerSaar</name>
-	<version>1.0</version>
-	<creationDate>05/09/2013</creationDate>
-	<author>Gerhard Sitzmann</author>
-	<authorEmail>gbrh@webseiten-fuer-alle.de</authorEmail>
-	<copyright>Copyright (C) 2013 webseiten-fuer-alle.de.</copyright>
+	<name>oneweb</name>
+	<version>3.0</version>
+	<creationDate>30/04/2013</creationDate>
+	<author>Seth Warburton</author>
+	<authorEmail>seth@internet-inspired.com</authorEmail>
+	<copyright>Copyright (C) 2013 Internet Inspired. All rights reserved.</copyright>
 	<description>TPL_ONEWEB_XML_DESCRIPTION</description>
 	<files>
         <filename>apple-touch-icon.png</filename>


### PR DESCRIPTION
I raised the issue about the JS error already on your blog. Now here is the pull request.

Also I extended backend options to allow choice whether to use Google web fonts at all.
This is a convenience option for people who don't want to use Googe Webfonts in their project. Now they don't have to comment out the GFont stuff in logic.php.
Also I found what I think must be a typo in _fluid-type.scss.
